### PR TITLE
feat: create cert directly from CSR configuration

### DIFF
--- a/cmd/create/cert/cert.go
+++ b/cmd/create/cert/cert.go
@@ -5,15 +5,19 @@ import (
 	"os"
 
 	"github.com/spf13/cobra"
+	"sigs.k8s.io/yaml"
 
 	"go.e13.dev/certman/pkg/ca"
+	"go.e13.dev/certman/pkg/cert"
 	"go.e13.dev/certman/pkg/flags"
 )
 
 func NewCommand() *cobra.Command {
 	csrFlag := flags.Flag{
-		Name:      "csr",
-		Validator: flags.DisallowEmpty{},
+		Name: "csr",
+	}
+	csrCfgFlag := flags.Flag{
+		Name: "csr-config",
 	}
 	caKeyFlag := flags.Flag{
 		Name:      "ca-key",
@@ -27,17 +31,52 @@ func NewCommand() *cobra.Command {
 		Name:      "out",
 		Validator: flags.DisallowEmpty{},
 	}
+	privkeyOutFlag := flags.Flag{
+		Name: "privkey-out",
+	}
+
+	var csrConfig cert.CSRConfig
 
 	cmd := cobra.Command{
 		Use:   "cert",
 		Short: "Create a certificate from a CSR signed by a CA",
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return flags.Validate(csrFlag, caKeyFlag, caCertFlag, outFlag)
+			if err := flags.Validate(
+				flags.Exclusive(csrFlag, csrCfgFlag),
+				flags.And(csrCfgFlag, privkeyOutFlag),
+				caKeyFlag,
+				caCertFlag,
+				outFlag); err != nil {
+				return err
+			}
+			if csrCfgFlag.Val != "" {
+				cfgData, err := os.ReadFile(csrCfgFlag.Val)
+				if err != nil {
+					return fmt.Errorf("failed to read configuration file '%s': %w", csrCfgFlag.Val, err)
+				}
+				if err := yaml.Unmarshal(cfgData, &csrConfig); err != nil {
+					return fmt.Errorf("failed to parse configuration file '%s': %w", csrCfgFlag.Val, err)
+				}
+			}
+			return nil
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
-			csr, err := os.ReadFile(csrFlag.Val)
-			if err != nil {
-				return fmt.Errorf("failed to read CSR file '%s': %w", csrFlag.Val, err)
+			var csrPEM []byte
+			if csrCfgFlag.Val != "" {
+				csr, err := cert.CreateCSR(&csrConfig)
+				if err != nil {
+					return fmt.Errorf("failed to create CSR: %w", err)
+				}
+				if err := os.WriteFile(privkeyOutFlag.Val, csr.PrivateKey, 0o600); err != nil {
+					return fmt.Errorf("failed to write the private key file: %w", err)
+				}
+				csrPEM = csr.Request
+			} else {
+				var err error
+				csrPEM, err = os.ReadFile(csrFlag.Val)
+				if err != nil {
+					return fmt.Errorf("failed to read CSR file '%s': %w", csrFlag.Val, err)
+				}
 			}
 			caKey, err := os.ReadFile(caKeyFlag.Val)
 			if err != nil {
@@ -48,7 +87,7 @@ func NewCommand() *cobra.Command {
 				return fmt.Errorf("failed to read CA key file '%s': %w", caKeyFlag.Val, err)
 			}
 
-			cert, err := ca.CreateCertificate(csr, caCert, caKey)
+			cert, err := ca.CreateCertificate(csrPEM, caCert, caKey)
 			if err != nil {
 				return fmt.Errorf("failed to create certificate: %w", err)
 			}
@@ -63,6 +102,10 @@ func NewCommand() *cobra.Command {
 	}
 
 	cmd.PersistentFlags().StringVar(&csrFlag.Val, csrFlag.Name, "", "filename of the CSR")
+	cmd.PersistentFlags().StringVar(
+		&csrCfgFlag.Val, csrCfgFlag.Name, "", "filename of the input configuration for the CSR")
+	cmd.PersistentFlags().StringVar(
+		&privkeyOutFlag.Val, privkeyOutFlag.Name, "", "filename to use for storing the private key")
 	cmd.PersistentFlags().StringVar(&caKeyFlag.Val, caKeyFlag.Name, "", "filename of the CA's private key")
 	cmd.PersistentFlags().StringVar(&caCertFlag.Val, caCertFlag.Name, "", "filename of the CA's certificate")
 	cmd.PersistentFlags().StringVar(&outFlag.Val, outFlag.Name, "", "filename to use for storing the certificate")

--- a/cmd/create/csr/csr.go
+++ b/cmd/create/csr/csr.go
@@ -47,7 +47,7 @@ func NewCommand() *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			csr, err := cert.CreateCSR(&cfg)
 			if err != nil {
-				return fmt.Errorf("failed to create CA: %w", err)
+				return fmt.Errorf("failed to create CSR: %w", err)
 			}
 
 			err = os.WriteFile(csrOutFlag.Val, csr.Request, 0o644) //nolint:gosec // doesn't contain sensitive data

--- a/pkg/ca/sign.go
+++ b/pkg/ca/sign.go
@@ -43,6 +43,7 @@ func CreateCertificate(csrPEM, caPEM, caKeyPEM []byte) ([]byte, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to generate serial number: %w", err)
 	}
+
 	cert := x509.Certificate{
 		SerialNumber: ser,
 		Issuer:       caCert.Subject,

--- a/pkg/flags/flags.go
+++ b/pkg/flags/flags.go
@@ -1,6 +1,9 @@
 package flags
 
-import "fmt"
+import (
+	"fmt"
+	"strings"
+)
 
 type Flag struct {
 	Name      string
@@ -22,6 +25,10 @@ type Validator interface {
 	Validate(val string) error
 }
 
+type Validatable interface {
+	Validate() error
+}
+
 type DisallowEmpty struct{}
 
 func (v DisallowEmpty) Validate(val string) error {
@@ -29,4 +36,58 @@ func (v DisallowEmpty) Validate(val string) error {
 		return fmt.Errorf("value cannot be empty")
 	}
 	return nil
+}
+
+type exclusive struct {
+	flags []Flag
+}
+
+func Exclusive(flags ...Flag) exclusive {
+	return exclusive{flags: flags}
+}
+
+func (e exclusive) Validate() error {
+	hasNonEmpty := false
+	for _, f := range e.flags {
+		if f.Val != "" {
+			if hasNonEmpty {
+				return e.error()
+			}
+			hasNonEmpty = true
+		}
+	}
+	return nil
+}
+
+func (e exclusive) error() error {
+	names := make([]string, len(e.flags))
+	for idx, f := range e.flags {
+		names[idx] = "--" + f.Name
+	}
+	return fmt.Errorf("only one of %s must be set", strings.Join(names, ", "))
+}
+
+type and struct {
+	flags []Flag
+}
+
+func And(flags ...Flag) and {
+	return and{flags: flags}
+}
+
+func (a and) Validate() error {
+	for _, f := range a.flags {
+		if f.Val == "" {
+			return a.error()
+		}
+	}
+	return nil
+}
+
+func (a and) error() error {
+	names := make([]string, len(a.flags))
+	for idx, f := range a.flags {
+		names[idx] = "--" + f.Name
+	}
+	return fmt.Errorf("all of %s must be set", strings.Join(names, ", "))
 }

--- a/pkg/flags/validate.go
+++ b/pkg/flags/validate.go
@@ -1,8 +1,8 @@
 package flags
 
-func Validate(flags ...Flag) error {
-	for _, flag := range flags {
-		if err := flag.Validate(); err != nil {
+func Validate(validators ...Validatable) error {
+	for _, validator := range validators {
+		if err := validator.Validate(); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
This lets users skip the CSR creation step and go directly to the
certificate creation in case they have access to the CA cert and key.